### PR TITLE
Update docs for listing devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ True
 ### Listing devices, state, model and device id
 
 ```pycon
->>> for device in my_home.list_devices:
+>>> for device in my_home.get_devices:
 ...   print(f"Device: {device['name']}")
 ...   print(f"Device ID: {device['device_id']})
 ...   print(f"Model: {device['model_name']})
@@ -58,7 +58,7 @@ Online: True
 
 ### Listing last device motion events
 
-```pycon   
+```pycon
 >>> motion_events = my_home.get_motion_events(device_id="00000222222222222222222")
 >>> for event in motion_events[:2]:
 ...    print(f"snapshot: {event['snapshot']}")

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,7 +68,7 @@ Listing devices, state, model and device id
 
 .. code-block:: python
 
-    >>> for device in my_home.list_devices:
+    >>> for device in my_home.get_devices:
     ...   print(f"Device: {device['name']}")
     ...   print(f"Device ID: {device['device_id']})
     ...   print(f"Model: {device['model_name']})

--- a/kodaksmarthome/api.py
+++ b/kodaksmarthome/api.py
@@ -377,7 +377,7 @@ class KodakSmartHome:
         Get all device events
 
         :param device_id: device id available in the device information
-            ``KodakSmartHome.list_devices``
+            ``KodakSmartHome.get_devices``
         :type device_id: str
         :return: list events
         :rtype: list
@@ -405,7 +405,7 @@ class KodakSmartHome:
         Filter events from device by event type.
 
         :param device_id: device id available in the device information
-            ``KodakSmartHome.list_devices``
+            ``KodakSmartHome.get_devices``
         :param event_type: Possible events``kodaksmarthome.constants``:
             DEVICE_EVENT_MOTION, DEVICE_EVENT_SOUND, DEVICE_EVENT_BATTERY.
             Default: DEVICE_EVENT_MOTION


### PR DESCRIPTION
From what I can tell, there's no more `list_devices`, but the docs keep referencing it. This PR updates the docs to replace `list_devices` with `get_devices`.